### PR TITLE
Multiple triggers and extra context

### DIFF
--- a/pghistory/core.py
+++ b/pghistory/core.py
@@ -27,14 +27,19 @@ def _get_name_from_label(label):
     else:  # pragma: no cover
         return None
 
+def _get_tracker_type_from_class(tracker_class):
+    return re.sub(r'(?<!^)(?=[A-Z])', '_', type(tracker_class).__name__).lower()
+
 
 class Tracker:
     """For tracking an event when a condition happens on a model."""
 
     label = None
+    type = None
 
     def __init__(self, label=None):
         self.label = label or self.label or self.__class__.__name__.lower()
+        self.type = _get_tracker_type_from_class(self)
 
     def setup(self, event_model):
         """Set up the tracker for the event model"""
@@ -44,14 +49,14 @@ class Tracker:
         """Registers the tracker for the event model and calls user-defined setup"""
         tracked_model = event_model.pgh_tracked_model
 
-        if (tracked_model, self.label) in _registered_trackers:
+        if (tracked_model, self.label, self.type) in _registered_trackers:
             raise ValueError(
-                f'Tracker with label "{self.label}" already exists'
+                f'Tracker with label "{self.label}" and type "{self.type}" already exists'
                 f' for model "{tracked_model._meta.label}". Supply a'
                 " different label as the first argument to the tracker."
             )
 
-        _registered_trackers[(tracked_model, self.label)] = event_model
+        _registered_trackers[(tracked_model, self.label, self.type)] = event_model
 
     def pghistory_setup(self, event_model):
         self.register(event_model)
@@ -89,6 +94,7 @@ class DatabaseTracker(Tracker):
         condition=None,
         operation=None,
         snapshot=None,
+        extra_context=None,
     ):
         super().__init__(label=label)
 
@@ -96,17 +102,19 @@ class DatabaseTracker(Tracker):
         self.condition = condition or self.condition
         self.operation = operation or self.operation
         self.snapshot = snapshot or self.snapshot
+        self.extra_context = extra_context or {}
 
     def setup(self, event_model):
         pgtrigger.register(
             trigger.Event(
                 event_model=event_model,
                 label=self.label,
-                name=_get_name_from_label(self.label),
+                name=_get_name_from_label(f"{self.label}_{self.type}"),
                 snapshot=self.snapshot,
                 when=self.when,
                 operation=self.operation,
                 condition=self.condition,
+                extra_context=self.extra_context
             )
         )(event_model.pgh_tracked_model)
 
@@ -253,8 +261,8 @@ class PreconfiguredDatabaseTracker(DatabaseTracker):
     preconfigure the other parameters
     """
 
-    def __init__(self, label=None, *, condition=None):
-        return super().__init__(label=label, condition=condition)
+    def __init__(self, label=None, *, condition=None, extra_context=None):
+        return super().__init__(label=label, condition=condition, extra_context=extra_context)
 
 
 class AfterInsertOrUpdate(PreconfiguredDatabaseTracker):
@@ -746,7 +754,7 @@ class _InsertEventCompiler(compiler.SQLInsertCompiler):
         return [(ret[0][0], params)]
 
 
-def create_event(obj, *, label, using="default"):
+def create_event(obj, *, label, tracker_class, using="default"):
     """Manually create a event for an object.
 
     Events are automatically linked with any context being tracked
@@ -762,13 +770,15 @@ def create_event(obj, *, label, using="default"):
     Returns:
         models.Model: The created event model.
     """
+    tracker_type = _get_tracker_type_from_class(tracker_class)
+
     # Verify that the provided label is tracked
-    if (obj.__class__, label) not in _registered_trackers:
+    if (obj.__class__, label, tracker_type) not in _registered_trackers:
         raise ValueError(
             f'"{label}" is not a registered tracker label for model {obj._meta.object_name}.'
         )
 
-    event_model = _registered_trackers[(obj.__class__, label)]
+    event_model = _registered_trackers[(obj.__class__, label, tracker_type)]
     event_model_kwargs = {
         "pgh_label": label,
         **{

--- a/pghistory/middleware.py
+++ b/pghistory/middleware.py
@@ -1,10 +1,11 @@
 from django.core.handlers.wsgi import WSGIRequest as DjangoWSGIRequest
+from django.core.handlers.asgi import ASGIRequest as DjangoASGIRequest
 
 import pghistory
 from pghistory import config
 
 
-class WSGIRequest(DjangoWSGIRequest):
+class DjangoRequest:
     """
     Although Django's auth middleware sets the user in middleware,
     apps like django-rest-framework set the user in the view layer.
@@ -20,6 +21,12 @@ class WSGIRequest(DjangoWSGIRequest):
             pghistory.context(user=value.pk if value and hasattr(value, "pk") else None)
 
         return super().__setattr__(attr, value)
+
+class WSGIRequest(DjangoRequest, DjangoWSGIRequest):
+    pass
+
+class ASGIRequest(DjangoRequest, DjangoASGIRequest):
+    pass
 
 
 def HistoryMiddleware(get_response):
@@ -37,6 +44,8 @@ def HistoryMiddleware(get_response):
             with pghistory.context(user=user, url=request.path):
                 if isinstance(request, DjangoWSGIRequest):  # pragma: no branch
                     request.__class__ = WSGIRequest
+                elif isinstance(request, DjangoASGIRequest):  # pragma: no branch
+                    request.__class__ = ASGIRequest
 
                 return get_response(request)
         else:

--- a/pghistory/utils.py
+++ b/pghistory/utils.py
@@ -20,7 +20,7 @@ class Operation(IntegerChoices):
     INSERT = 1
     UPDATE = 2
     DELETE = 3
-
+    INSERTORUPDATE = 4
 
 def related_model(field):
     """Return the concrete model a field references"""


### PR DESCRIPTION
This fixes 2 bugs:
- missing operation on enum for the AfterInsertOrUpdate trigger
- create_event function not working with a ContextJSONField

And adds 2 features:
- Being able to declare multiple (different) triggers with the same label
- Being able to pass an arbitrary fixed context when the trigger is called. This is to append additional data to specific events.